### PR TITLE
Allow specifying ColorConversion as a property of the `Predict` operator

### DIFF
--- a/src/Bonsai.TensorFlow.MoveNet/Bonsai.TensorFlow.MoveNet.csproj
+++ b/src/Bonsai.TensorFlow.MoveNet/Bonsai.TensorFlow.MoveNet.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx MoveNet Pose Estimation</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
@@ -68,7 +68,7 @@ namespace Bonsai.TensorFlow.MoveNet
                     var batchSize = input.Length;
                     if (batchSize > 1) { throw new NotImplementedException("Batch processing not implemented"); }
 
-                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width )
+                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width || tensor.Shape[3] != colorChannels)
                     {
                         tensor?.Dispose();
                         runner = session.GetRunner();

--- a/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
@@ -62,7 +62,7 @@ namespace Bonsai.TensorFlow.MoveNet
                 var tensorSize = new Size(InputSize, InputSize);
                 return source.Select(input =>
                 {
-                    int colorChannels = input[0].Channels;
+                    int colorChannels = ColorConversion.HasValue ? ExtensionMethods.GetConversionNumChannels(ColorConversion.Value) : input[0].Channels;
                     var initialSize = input[0].Size;
 
                     var batchSize = input.Length;

--- a/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictMultiPoseLightning.cs
@@ -32,6 +32,12 @@ namespace Bonsai.TensorFlow.MoveNet
         public float MinimumConfidence { get; set; } = 0;
 
         /// <summary>
+        /// Gets or sets the optional color conversion used to prepare images for inference.
+        /// </summary>
+        [Description("The optional color conversion used to prepare images for inference.")]
+        public ColorConversion? ColorConversion { get; set; } = OpenCV.Net.ColorConversion.Bgr2Rgb;
+
+        /// <summary>
         /// Performs markerless, multiple instance (<6), pose estimation for each array
         /// of images in an observable sequence using a movenet_multipose_lighting_v1 model.
         /// </summary>
@@ -46,6 +52,7 @@ namespace Bonsai.TensorFlow.MoveNet
             return Observable.Defer(() =>
             {
                 IplImage resizeTemp = null;
+                IplImage colorTemp = null;
                 TFTensor tensor = null;
                 TFSession.Runner runner = null;
                 var availableBodyParts = ExtensionMethods.GetBodyParts();
@@ -72,6 +79,7 @@ namespace Bonsai.TensorFlow.MoveNet
                     var frames = Array.ConvertAll(input, frame => 
                     {
                         frame = TensorHelper.EnsureFrameSize(frame, tensorSize, ref resizeTemp);
+                        frame = TensorHelper.EnsureColorFormat(frame, ColorConversion, ref colorTemp);
                         return frame;
                     });
                     TensorHelper.UpdateTensor(tensor, colorChannels, Depth.S32, frames);

--- a/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseLightning.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseLightning.cs
@@ -62,7 +62,7 @@ namespace Bonsai.TensorFlow.MoveNet
                 var tensorSize = new Size(InputSize, InputSize);
                 return source.Select(input =>
                 {
-                    int colorChannels = input[0].Channels;
+                    int colorChannels = ColorConversion.HasValue ? ExtensionMethods.GetConversionNumChannels(ColorConversion.Value) : input[0].Channels;
                     var initialSize = input[0].Size;
 
                     var batchSize = input.Length;

--- a/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseLightning.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseLightning.cs
@@ -68,7 +68,7 @@ namespace Bonsai.TensorFlow.MoveNet
                     var batchSize = input.Length;
                     if (batchSize > 1) { throw new NotImplementedException("Batch processing not implemented"); }
 
-                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width)
+                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width || tensor.Shape[3] != colorChannels)
                     {
                         tensor?.Dispose();
                         runner = session.GetRunner();

--- a/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseThunder.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseThunder.cs
@@ -69,7 +69,7 @@ namespace Bonsai.TensorFlow.MoveNet
                     var batchSize = input.Length;
                     if (batchSize > 1) { throw new NotImplementedException("Batch processing not implemented"); }
 
-                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width)
+                    if (tensor == null || tensor.Shape[0] != batchSize || tensor.Shape[1] != tensorSize.Height || tensor.Shape[2] != tensorSize.Width || tensor.Shape[3] != colorChannels)
                     {
                         tensor?.Dispose();
                         runner = session.GetRunner();

--- a/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseThunder.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/PredictSinglePoseThunder.cs
@@ -63,7 +63,7 @@ namespace Bonsai.TensorFlow.MoveNet
                 var tensorSize = new Size(InputSize, InputSize);
                 return source.Select(input =>
                 {
-                    int colorChannels = input[0].Channels;
+                    int colorChannels = ColorConversion.HasValue ? ExtensionMethods.GetConversionNumChannels(ColorConversion.Value) : input[0].Channels;
                     var initialSize = input[0].Size;
 
                     var batchSize = input.Length;

--- a/src/Bonsai.TensorFlow.MoveNet/TensorHelper.cs
+++ b/src/Bonsai.TensorFlow.MoveNet/TensorHelper.cs
@@ -47,7 +47,7 @@ namespace Bonsai.TensorFlow.MoveNet
                 DType,
                 new long[] { batchSize, frameSize.Height, frameSize.Width, TensorChannels },
                 batchSize * frameSize.Width * frameSize.Height * TensorChannels * numberOfBytes);
-            runner.AddInput(graph["x"][0], tensor); 
+            runner.AddInput(graph["x"][0], tensor);
             return tensor;
         }
 
@@ -75,6 +75,21 @@ namespace Bonsai.TensorFlow.MoveNet
                 }
                 CV.Resize(frame, resizeTemp);
                 frame = resizeTemp;
+            }
+            return frame;
+        }
+
+        public static IplImage EnsureColorFormat(IplImage frame, ColorConversion? colorConversion, ref IplImage colorTemp)
+        {
+            if (colorConversion != null)
+            {
+                var nChannels = ExtensionMethods.GetConversionNumChannels(colorConversion.Value);
+                if (colorTemp == null || colorTemp.Size != frame.Size | colorTemp.Channels != nChannels)
+                {
+                    colorTemp = new IplImage(frame.Size, frame.Depth, nChannels);
+                }
+                CV.CvtColor(frame, colorTemp, colorConversion.Value);
+                frame = colorTemp;
             }
             return frame;
         }


### PR DESCRIPTION
This PR exposes a `ColorConversion` as a public property of all `Predict` operators. By default it attempts to convert `BGR` -> `RGB` since this is the expected colorspace of the network.
